### PR TITLE
Fix "docker --name" command line option.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,6 +10,6 @@ REPOSITORY=stucki/cyanogenmod
 test -d $SOURCE || mkdir $SOURCE
 
 # Try to start an existing/stopped container with the given name $CONTAINER. Otherwise, run a new one.
-docker start -i $CONTAINER 2>/dev/null || docker run -v $SOURCE:/home/cmbuild/android -i -t -name $CONTAINER $REPOSITORY sh -c "screen -s /bin/bash"
+docker start -i $CONTAINER 2>/dev/null || docker run -v $SOURCE:/home/cmbuild/android -i -t --name $CONTAINER $REPOSITORY sh -c "screen -s /bin/bash"
 
 exit $?


### PR DESCRIPTION
Option "-name" to docker is obsolete.

Signed-off-by: Gianpaolo Macario gmacario@gmail.com
