### PR TITLE
Volume compatibility with SELinux-enabled systems

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -70,7 +70,7 @@ if [[ $IS_RUNNING == "true" ]]; then
 elif [[ $IS_RUNNING == "false" ]]; then
 	docker start -i $CONTAINER
 else
-	docker run $PRIVILEGED -v $SOURCE:$CONTAINER_HOME/android -v $CCACHE:/srv/ccache -i -t --name $CONTAINER $REPOSITORY:$TAG
+	docker run $PRIVILEGED -v $SOURCE:$CONTAINER_HOME/android:Z -v $CCACHE:/srv/ccache:Z -i -t --name $CONTAINER $REPOSITORY:$TAG
 fi
 
 exit $?


### PR DESCRIPTION
Make use of volume tags to avoid problems with SELinux. Not setting these tags results in permission errors when trying to access the volumes within the running container.

https://docs.docker.com/engine/tutorials/dockervolumes/#/volume-labels