### PR TITLE
android-env-vars: Use ccache compression

### DIFF
--- a/android-env-vars.sh
+++ b/android-env-vars.sh
@@ -1,3 +1,4 @@
 export PATH=/home/build/bin:$PATH
 export USE_CCACHE=1
 export CCACHE_DIR=/srv/ccache
+export CCACHE_COMPRESS=1


### PR DESCRIPTION
From https://ccache.samba.org/manual.html#_cache_compression:

> ccache can optionally compress all files it puts into the cache using the compression library zlib. While this may involve a tiny performance slowdown, it increases the number of files that fit in the cache.