### PR TITLE
Ensure build user has the same UID and GID as the host user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,13 @@ RUN apt-get install -y android-tools-adb android-tools-fastboot
 RUN apt-get install -y bc bsdmainutils file screen
 RUN apt-get install -y bash-completion wget nano
 
-RUN useradd build && rsync -a /etc/skel/ /home/build/
+ARG hostuid=1000
+ARG hostgid=1000
+
+RUN \
+    groupadd build -g $hostgid && \
+    useradd build -g $hostgid -u $hostuid && \
+    rsync -a /etc/skel/ /home/build/
 
 RUN mkdir /home/build/bin
 RUN curl http://commondatastorage.googleapis.com/git-repo-downloads/repo > /home/build/bin/repo

--- a/run.sh
+++ b/run.sh
@@ -48,7 +48,9 @@ elif [[ $FORCE_BUILD = 1 ]] || ! echo "$IMAGE_EXISTS" | grep -q "$TAG"; then
 	docker pull ubuntu:16.04
 
 	echo "Building Docker image $REPOSITORY:$TAG..."
-	docker build -t $REPOSITORY:$TAG .
+	USERID=$(id -u)
+	GROUPID=$(id -g)
+	docker build -t $REPOSITORY:$TAG --build-arg hostuid=$USERID --build-arg hostgid=$GROUPID .
 	OK=$?
 
 	# After successful build, delete existing containers


### PR DESCRIPTION
This prevents permission problems since volume owners are set from host user.

I have only tested this on my PC and it seems like the kind of thing that needs more testing, so please review.