### PR TITLE
move apt stuff into one RUN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,23 +3,57 @@
 FROM ubuntu:16.04
 MAINTAINER Michael Stucki <michael@stucki.io>
 
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN sed -i 's/main$/main universe/' /etc/apt/sources.list
-RUN apt-get -qq update
-RUN apt-get -qqy upgrade
-
+RUN sed -i 's/main$/main universe/' /etc/apt/sources.list \
+ && export DEBIAN_FRONTEND=noninteractive \
+ && apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y \
 # Install build dependencies (source: https://wiki.cyanogenmod.org/w/Build_for_bullhead)
-RUN apt-get install -y bison build-essential curl flex git gnupg gperf libesd0-dev liblz4-tool libncurses5-dev libsdl1.2-dev libwxgtk3.0-dev libxml2 libxml2-utils lzop maven openjdk-8-jdk pngcrush schedtool squashfs-tools xsltproc zip zlib1g-dev
-
+      bison \
+      build-essential \
+      curl \
+      flex \
+      git \
+      gnupg \
+      gperf \
+      libesd0-dev \
+      liblz4-tool \
+      libncurses5-dev \
+      libsdl1.2-dev \
+      libwxgtk3.0-dev \
+      libxml2 \
+      libxml2-utils \
+      lzop \
+      maven \
+      openjdk-8-jdk \
+      pngcrush \
+      schedtool \
+      squashfs-tools \
+      xsltproc \
+      zip \
+      zlib1g-dev \
 # For 64-bit systems
-RUN apt-get install -y g++-multilib gcc-multilib lib32ncurses5-dev lib32readline6-dev lib32z1-dev
-
+      g++-multilib \
+      gcc-multilib \
+      lib32ncurses5-dev \
+      lib32readline6-dev \
+      lib32z1-dev \
 # Install additional packages which are useful for building Android
-RUN apt-get install -y ccache rsync tig sudo imagemagick
-RUN apt-get install -y android-tools-adb android-tools-fastboot
-RUN apt-get install -y bc bsdmainutils file screen
-RUN apt-get install -y bash-completion wget nano
+      android-tools-adb \
+      android-tools-fastboot \
+      bash-completion \
+      bc \
+      bsdmainutils \
+      ccache \
+      file \
+      imagemagick \
+      nano \
+      rsync \
+      screen \
+      sudo \
+      tig \
+      wget \
+ && rm -rf /var/lib/apt/lists/*
 
 ARG hostuid=1000
 ARG hostgid=1000


### PR DESCRIPTION
Hi @stucki 

I followed your work on the X5+ and seen your container here. Nice work. I'm currently trying to build lineageos with this container for myself.

I've updated the stack of apt-calls to better match [docker's best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#apt-get).

Ok, it's actually nothing in comparison to the later size lineageos root, but this also saves 50M (5%) in the container image.