### PR TITLE
Various improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN chown -R build:build /home/build
 VOLUME /home/build/android
 VOLUME /srv/ccache
 
-CMD /home/build/startup.sh
-
 USER build
 WORKDIR /home/build/android
+
+CMD /home/build/startup.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,13 @@
 FROM ubuntu:16.04
 MAINTAINER Michael Stucki <michael@stucki.io>
 
+
 ENV \
+# ccache specifics
+    CCACHE_SIZE=50G \
+    CCACHE_DIR=/srv/ccache \
+    USE_CCACHE=1 \
+    CCACHE_COMPRESS=1 \
 # Extra include PATH, it may not include /usr/local/(s)bin on some systems
     PATH=$PATH:/usr/local/bin/
 
@@ -78,10 +84,6 @@ RUN chmod a+x /home/build/startup.sh
 
 # Fix ownership
 RUN chown -R build:build /home/build
-
-# Set global variables
-ADD android-env-vars.sh /etc/android-env-vars.sh
-RUN echo "source /etc/android-env-vars.sh" >> /etc/bash.bashrc
 
 VOLUME /home/build/android
 VOLUME /srv/ccache

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@
 FROM ubuntu:16.04
 MAINTAINER Michael Stucki <michael@stucki.io>
 
+ENV \
+# Extra include PATH, it may not include /usr/local/(s)bin on some systems
+    PATH=$PATH:/usr/local/bin/
+
 RUN sed -i 's/main$/main universe/' /etc/apt/sources.list \
  && export DEBIAN_FRONTEND=noninteractive \
  && apt-get update \
@@ -63,9 +67,8 @@ RUN \
     useradd --gid $hostgid --uid $hostuid --non-unique build && \
     rsync -a /etc/skel/ /home/build/
 
-RUN mkdir /home/build/bin
-RUN curl http://commondatastorage.googleapis.com/git-repo-downloads/repo > /home/build/bin/repo
-RUN chmod a+x /home/build/bin/repo
+RUN curl http://commondatastorage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo \
+ && chmod a+x /usr/local/bin/repo
 
 # Add sudo permission
 RUN echo "build ALL=NOPASSWD: ALL" > /etc/sudoers.d/build

--- a/android-env-vars.sh
+++ b/android-env-vars.sh
@@ -1,4 +1,3 @@
-export PATH=/home/build/bin:$PATH
 export USE_CCACHE=1
 export CCACHE_DIR=/srv/ccache
 export CCACHE_COMPRESS=1

--- a/android-env-vars.sh
+++ b/android-env-vars.sh
@@ -1,3 +1,0 @@
-export USE_CCACHE=1
-export CCACHE_DIR=/srv/ccache
-export CCACHE_COMPRESS=1

--- a/run.sh
+++ b/run.sh
@@ -30,6 +30,9 @@ while [[ $# > 0 ]]; do
 done
 
 # Create shared folders
+# Although Docker would create non-existing directories on the fly,
+# we need to have them owned by the user (and not root), to be able
+# to write in them, which is a necessity for startup.sh
 mkdir -p $SOURCE
 mkdir -p $CCACHE
 

--- a/run.sh
+++ b/run.sh
@@ -53,7 +53,7 @@ elif [[ $FORCE_BUILD = 1 ]] || ! echo "$IMAGE_EXISTS" | grep -q "$TAG"; then
 	# After successful build, delete existing containers
 	IS_EXISTING=$(docker inspect -f '{{.Id}}' $CONTAINER 2>/dev/null) || true
 	if [[ -n $IS_EXISTING ]]; then
-		docker rm $CONTAINER
+		docker rm $CONTAINER >/dev/null
 	fi
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -36,13 +36,12 @@ done
 mkdir -p $SOURCE
 mkdir -p $CCACHE
 
+command -v docker >/dev/null \
+	|| { echo "command 'docker' not found."; exit 1; }
+
 # Build image if needed
-IMAGE_EXISTS=$(docker images $REPOSITORY)
-if [ $? -ne 0 ]; then
-	echo "docker command not found"
-	exit $?
-elif [[ $FORCE_BUILD = 1 ]] || ! echo "$IMAGE_EXISTS" | grep -q "$TAG"; then
-	echo "Building Docker image $REPOSITORY:$TAG..."
+if [[ $FORCE_BUILD = 1 ]] || ! docker inspect $REPOSITORY:$TAG &>/dev/null; then
+
 	docker build \
 		--pull \
 		-t $REPOSITORY:$TAG \
@@ -51,8 +50,7 @@ elif [[ $FORCE_BUILD = 1 ]] || ! echo "$IMAGE_EXISTS" | grep -q "$TAG"; then
 		.
 
 	# After successful build, delete existing containers
-	IS_EXISTING=$(docker inspect -f '{{.Id}}' $CONTAINER 2>/dev/null) || true
-	if [[ -n $IS_EXISTING ]]; then
+	if docker inspect $CONTAINER &>/dev/null; then
 		docker rm $CONTAINER >/dev/null
 	fi
 fi

--- a/startup.sh
+++ b/startup.sh
@@ -6,7 +6,9 @@ if [ ! -f ${CCACHE_DIR}/ccache.conf ]; then
 	ccache -M ${CCACHE_SIZE}
 fi
 
-export USER="build"
+# in Docker, the USER variable is unset by default
+# but some programs (like jack toolchain) rely on it
+export USER="$(whoami)"
 
 # Launch screen session
 screen -s /bin/bash

--- a/startup.sh
+++ b/startup.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 # Initialize ccache if needed
-if [ ! -f /srv/ccache/ccache.conf ]; then
+if [ ! -f ${CCACHE_DIR}/ccache.conf ]; then
 	echo "Initializing ccache in /srv/ccache..."
-	CCACHE_DIR=/srv/ccache ccache -M 50G
+	ccache -M ${CCACHE_SIZE}
 fi
 
 export USER="build"


### PR DESCRIPTION
This PR contains various improvements. Here's a description with each commit:

## *move repo command to /usr/local* @ c66a2ba

Put the `repo`-command on into `/usr/local/bin`. Then the whole stuff about patching bashrc is not needed anymore.

## *remove android-env-vars.sh* @ 3047d50

Put the put the remaining exports into docker's `ENV`s. The be correct in detail, **now** the whole stuff about patching bashrc is not needed anymore. Also the `startup.sh`-script can use now the different variables.

bash and shells behave very differently on login process. In some occurences, the variables wouldn't be loaded (If you want to read about that, use `man bash` and read about the invocation (holy shit!). It's more persistent to have `ENV`.

## *fix user permission specific problems* @ 4192dcd

The fault is embedded in the sequence of `CMD`, `USER` and `WORKDIR`. **`CMD` has to be last!**

`export USER="build" `: `USER` is **always** a readonly variable. (Edit: Unless user is not defined.) <del>So changing makes no difference.</del>

It still has to be included to have support for jack toolchain. I misinterpreted this at first and thought it was an attempt to switch the user.