### PR TITLE
Add with su flag to run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The `run.sh` script accepts the following switches:
 
 * -u|--enable-usb - runs the container in privileged mode (this way you can use adb right from the container)
 * -r|--rebuild - force rebuild the image from scratch
+* -ws|--with-su - Sets the WITH_SU environment variable to true (your builds will include the su binary)
 
 The container uses "screen" to run the shell. This means that you will be able to open additional shells using [screen keyboard shortcuts][Screen_Shortcuts].
 

--- a/run.sh
+++ b/run.sh
@@ -12,6 +12,7 @@ REPOSITORY=stucki/lineageos
 TAG=cm-14.1
 FORCE_BUILD=0
 PRIVILEGED=
+ENVIRONMENT=
 
 while [[ $# > 0 ]]; do
 	key="$1"
@@ -21,6 +22,9 @@ while [[ $# > 0 ]]; do
 			;;
 		-u|--enable-usb)
 			PRIVILEGED="--privileged -v /dev/bus/usb:/dev/bus/usb"
+			;;
+		-ws|--with-su)
+			ENVIRONMENT="-e WITH_SU=true"
 			;;
 		*)
 			shift # past argument or value
@@ -62,7 +66,7 @@ if [[ $IS_RUNNING == "true" ]]; then
 elif [[ $IS_RUNNING == "false" ]]; then
 	docker start -i $CONTAINER
 else
-	docker run $PRIVILEGED -v $SOURCE:$CONTAINER_HOME/android:Z -v $CCACHE:/srv/ccache:Z -i -t --name $CONTAINER $REPOSITORY:$TAG
+	docker run $PRIVILEGED -v $SOURCE:$CONTAINER_HOME/android:Z -v $CCACHE:/srv/ccache:Z -i -t $ENVIRONMENT --name $CONTAINER $REPOSITORY:$TAG
 fi
 
 exit $?


### PR DESCRIPTION
- Added `-ws` or `--with-su` flag to the run script which will set the `WITH_SU` environment variable inside the docker machine.
- Edited the documentation accordingly.

Resolves https://github.com/stucki/docker-lineageos/issues/41