### PR TITLE
Docs(README): Add adb instructions and use table for switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ breakfast <device codename>   # example: breakfast grouper
 brunch <device codename>      # example: brunch grouper
 ```
 
+### ADB in the container
+If you're on Linux and want to use adb from within the container running with `-u` might not be enough. Make sure you have the [Android udev rules](https://github.com/M0Rf30/android-udev-rules/blob/master/51-android.rules) installed on your host system so you can access your device without needing superuser permissions.
+
 ### Links
 
 For further information, check the following links:


### PR DESCRIPTION
* Added documentation for adb use on linux based systems.
* Put the available switches in a table to make it look better.

Resolves https://github.com/stucki/docker-lineageos/issues/43

> Can you create a pull request with updated README.md which lists the possibilities to run adb inside Docker? See also #11 (comment) which explains how it can be run via network...

I haven't really tried running adb over the network and I don't know how the changes made in the pull-request you linked changed the behaviour of adb over network so I haven't documented it.