### PR TITLE
Docs: Add adb instructions and use table for switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ breakfast <device codename>   # example: breakfast grouper
 brunch <device codename>      # example: brunch grouper
 ```
 
+### ADB in the container
+If you're on Linux and want to use adb from within the container running with `-u` might not be enough. Make sure you have the [Android udev rules](https://github.com/M0Rf30/android-udev-rules/blob/master/51-android.rules) installed on your host system so you can access your device without needing superuser permissions.
+
 ### Links
 
 For further information, check the following links:

--- a/README.md
+++ b/README.md
@@ -24,11 +24,16 @@ cd docker-lineageos
 
 The `run.sh` script accepts the following switches:
 
-* -u|--enable-usb - runs the container in privileged mode (this way you can use adb right from the container)
-* -r|--rebuild - force rebuild the image from scratch
-* -ws|--with-su - Sets the WITH_SU environment variable to true (your builds will include the su binary)
+| Switch | Alternative | Description  |
+|---|---|---|
+| `-u` | `--enable-usb` | Runs the container in privileged mode (this way you can use adb right from the container) |
+| `-r` | `--rebuild` | Force rebuild the image from scratch |
+| `-ws` | `--with-su` | Sets the WITH_SU environment variable to true (your builds will include the su binary) |
 
 The container uses "screen" to run the shell. This means that you will be able to open additional shells using [screen keyboard shortcuts][Screen_Shortcuts].
+
+### ADB in the container
+If you're on Linux and want to use adb from within the container running with `-u` might not be enough. Make sure you have the [Android udev rules](https://github.com/M0Rf30/android-udev-rules/blob/master/51-android.rules) installed on your host system so you can access your device without needing superuser permissions.
 
 ### How to build LineageOS for your device
 
@@ -39,9 +44,6 @@ source build/envsetup.sh
 breakfast <device codename>   # example: breakfast grouper
 brunch <device codename>      # example: brunch grouper
 ```
-
-### ADB in the container
-If you're on Linux and want to use adb from within the container running with `-u` might not be enough. Make sure you have the [Android udev rules](https://github.com/M0Rf30/android-udev-rules/blob/master/51-android.rules) installed on your host system so you can access your device without needing superuser permissions.
 
 ### Links
 


### PR DESCRIPTION
* Added documentation for adb use on linux based systems.
* Put the available switches in a table to make it look better.

Resolves https://github.com/stucki/docker-lineageos/issues/43

> Can you create a pull request with updated README.md which lists the possibilities to run adb inside Docker? See also #11 (comment) which explains how it can be run via network...

I haven't really tried running adb over the network and I don't know how the changes made in the pull-request you linked changed the behaviour of adb over network so I haven't documented it.